### PR TITLE
Fix build with nodejs v16

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,7 +16,6 @@
         "eslint-config-prettier": "^7.2.0",
         "eslint-plugin-prettier": "^3.3.1",
         "eslint-plugin-svelte3": "^3.0.0",
-        "fibers": "^5.0.0",
         "jest": "^26.6.3",
         "jest-transform-svelte": "^2.1.1",
         "mini-css-extract-plugin": "^1.3.6",


### PR DESCRIPTION
Fibers is not compatible with nodejs v16.0.0 or later. But this seems to be unused anyway. Removed.